### PR TITLE
Add Laravel 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0"
+        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^3.4"


### PR DESCRIPTION
Adds `^11.0` to `illuminate/contracts` for Laravel 11 support